### PR TITLE
Refactor: change plants display to be collapsed instead of wide open

### DIFF
--- a/app/views/gardens/show.html.erb
+++ b/app/views/gardens/show.html.erb
@@ -17,15 +17,15 @@
         Facing</h3>
       <p class="lead">
         <%= @garden.notes %></p>
-    <br>
-    <div class="d-flex justify-content-center" role="search">
-      <%= form_with url: "/gardens/#{@garden.id}/plants", method: :get, local: true do |f| %>
-      <%= f.hidden_field :query, value: "name" %>
+      <br>
+      <div class="d-flex justify-content-center" role="search">
+        <%= form_with url: "/gardens/#{@garden.id}/plants", method: :get, local: true do |f| %>
+        <%= f.hidden_field :query, value: "name" %>
 
-      <div class="form-floating" id="formSelect" >
-      <%= f.text_field :search, class: "form-control me-2", type: "search" %>
-      <%= f.label "Plant Name Search", for: "formSelect" %>
-      </div>
+        <div class="form-floating" id="formSelect">
+          <%= f.text_field :search, class: "form-control me-2", type: "search" %>
+          <%= f.label "Plant Name Search", for: "formSelect" %>
+        </div>
 
         <%= f.submit "Find Plants to add to Garden", class: "btn btn-success" %>
 
@@ -41,7 +41,7 @@
               <%= plant.name %>
             </button>
           </h2>
-          <div id="collapse<%= index %>" class="accordion-collapse collapse show" aria-labelledby="headingOne" data-bs-parent="#accordionExample">
+          <div id="collapse<%= index %>" class="accordion-collapse collapse " aria-labelledby="headingOne" data-bs-parent="#accordionExample">
             <div class="plant-<%= plant.id %>">
               <div class="accordion-body">
 


### PR DESCRIPTION
### What does this PR do?
- Updates the garden show to have collapsed plant info instead of wide open.

### All tests passing?
- [X] Yes
- [ ] No

### SimpleCov 100%?
- [X] Yes
- [ ] No
- If No, what's missing:

### Has this been tested on LOCALHOST?
- [X] Yes
- [ ] No
- Did something not work? If so, what was it?

### Please add a meme/gif describing how you feel about this PR

![Caption](IMG URL HERE)