### PR TITLE
Add first quarter and third quarter into the moon helper module

### DIFF
--- a/app/modules/moon_helper.rb
+++ b/app/modules/moon_helper.rb
@@ -3,11 +3,11 @@ module MoonHelper
     moon_phase = phase.downcase
     if moon_phase.include?('dark')
       'Plant crops which produce seeds outside the fruit (grains, spinach, cauliflower, cabbage, broccoli, celery and lettuce).'
-    elsif moon_phase.include?('waxing') || moon_phase.include?('quarter')
+    elsif moon_phase.include?('waxing') || moon_phase.include?('first')
       'Plant crops with seeds inside the fruit (beans, peppers, tomatoes, squash and melons).'
     elsif moon_phase.include?('full')
       "Root vegetables, such as carrots, beets, onions and potatoes, will flourish. It's also a good time to transplant seedlings or to prune."
-    elsif moon_phase.include?('waning')
+    elsif moon_phase.include?('waning') || moon_phase.include?('third')
       'Avoid planting and focus on fertilizing the soil. This is the best time to mow grass, harvest, transplant and prune.'
     else
       "Interesting, this is a moon we don't have anything for! We will work on that!"


### PR DESCRIPTION
### What does this PR do?
Has the moon helper module return the correct information for first quarter and third quarter moon phases.

### All tests passing?
- [x] Yes
- [ ] No

### SimpleCov 100%?
- [ ] Yes
- [x] No
- If No, what's missing:
Moon service lines 4 and 5.

### Has this been tested on LOCALHOST?
- [ ] Yes
- [x] No
- Did something not work? If so, what was it?

